### PR TITLE
Nette v2.0.11 namespace fix

### DIFF
--- a/src/Kdyby/Redis/DI/RedisExtension.php
+++ b/src/Kdyby/Redis/DI/RedisExtension.php
@@ -21,9 +21,12 @@ use Nette\Utils\Validators;
 
 if (!class_exists('Nette\DI\CompilerExtension')) {
 	class_alias('Nette\Config\CompilerExtension', 'Nette\DI\CompilerExtension');
-	class_alias('Nette\Config\Configurator', 'Nette\Configurator');
 	class_alias('Nette\Config\Compiler', 'Nette\DI\Compiler');
 	class_alias('Nette\Config\Helpers', 'Nette\DI\Config\Helpers');
+}
+
+if (!class_exists('Nette\Configurator')) {
+	class_alias('Nette\Config\Configurator', 'Nette\Configurator');
 }
 
 /**


### PR DESCRIPTION
Added check for new Nette\Configurator namespace
