### PR TITLE
Authentication support

### DIFF
--- a/src/Kdyby/Redis/DI/RedisExtension.php
+++ b/src/Kdyby/Redis/DI/RedisExtension.php
@@ -52,6 +52,7 @@ class RedisExtension extends Nette\DI\CompilerExtension
 		'database' => 0,
 		'debugger' => '%debugMode%',
 		'versionCheck' => TRUE,
+		'auth' => NULL,
 	);
 
 
@@ -66,7 +67,8 @@ class RedisExtension extends Nette\DI\CompilerExtension
 				'host' => $config['host'],
 				'port' => $config['port'],
 				'database' => $config['database'],
-				'timeout' => $config['timeout']
+				'timeout' => $config['timeout'],
+				'auth' => $config['auth']
 			))
 			->addSetup('setupLockDuration', array($config['lockDuration']))
 			->addSetup('setPanel', array($this->prefix('@panel')));
@@ -105,6 +107,7 @@ class RedisExtension extends Nette\DI\CompilerExtension
 				'timeout' => $config['timeout'],
 				'database' => $config['database'],
 				'prefix' => self::DEFAULT_SESSION_PREFIX,
+				'auth' => $config['auth'],
 			));
 
 			$params = array_diff_key($session, array_flip(array('host', 'port')));
@@ -144,7 +147,7 @@ class RedisExtension extends Nette\DI\CompilerExtension
 	{
 		$config = $this->getConfig($this->defaults);
 		if ($config['versionCheck'] && ($config['journal'] || $config['storage'] || $config['session'])) {
-			$client = new RedisClient($config['host'], $config['port'], $config['database'], $config['timeout']);
+			$client = new RedisClient($config['host'], $config['port'], $config['database'], $config['timeout'], $config['auth']);
 			$client->assertVersion();
 			$client->close();
 		}

--- a/src/Kdyby/Redis/RedisClient.php
+++ b/src/Kdyby/Redis/RedisClient.php
@@ -206,8 +206,12 @@ class RedisClient extends Nette\Object implements \ArrayAccess
 	 */
 	private $lock;
 
-	private static $exceptionCmd = array('evalsha' => 0);
+	/**
+	 * @var string
+	 */
+	private $auth;
 
+	private static $exceptionCmd = array('evalsha' => 0);
 
 
 	/**
@@ -217,7 +221,7 @@ class RedisClient extends Nette\Object implements \ArrayAccess
 	 * @param int $timeout
 	 * @throws MissingExtensionException
 	 */
-	public function __construct($host = '127.0.0.1', $port = NULL, $database = 0, $timeout = 10)
+	public function __construct($host = '127.0.0.1', $port = NULL, $database = 0, $timeout = 10, $auth = NULL)
 	{
 		if (!extension_loaded('redis')) {
 			throw new MissingExtensionException("Please install and enable the redis extension. \nhttps://github.com/nicolasff/phpredis/");
@@ -227,6 +231,7 @@ class RedisClient extends Nette\Object implements \ArrayAccess
 		$this->port = $port;
 		$this->database = $database;
 		$this->timeout = $timeout;
+		$this->auth = $auth;
 
 		$this->driver = new Driver\PhpRedisDriver();
 	}
@@ -262,6 +267,11 @@ class RedisClient extends Nette\Object implements \ArrayAccess
 
 		try {
 			$this->driver->connect($this->host, $this->port, $this->timeout);
+
+			if (isset($this->auth)) {
+				$this->driver->auth($this->auth);
+			}
+
 			$this->driver->select($this->database);
 
 		} catch (\Exception $e) {


### PR DESCRIPTION
This patch adds support for optional redis authentication. The [AUTH command](http://redis.io/commands/auth) has to be called before any othe commands.
