### PR TITLE
Improved performance of exclusive locking

### DIFF
--- a/src/Kdyby/Redis/ExclusiveLock.php
+++ b/src/Kdyby/Redis/ExclusiveLock.php
@@ -85,6 +85,7 @@ class ExclusiveLock extends Nette\Object
 		$lockKey = $this->formatLock($key);
 		$maxAttempts = 10;
 		do {
+			$sleepTime = 5000;
 			do {
 				if ($this->client->setNX($lockKey, $timeout = $this->calculateTimeout())) {
 					$this->keys[$key] = $timeout;
@@ -92,7 +93,8 @@ class ExclusiveLock extends Nette\Object
 				}
 
 				$lockExpiration = $this->client->get($lockKey);
-			} while (empty($lockExpiration) || ($lockExpiration >= time() && !usleep(10000)));
+				$sleepTime *= 2;
+			} while (empty($lockExpiration) || ($lockExpiration >= time() && $sleepTime <= 1000000 && !usleep($sleepTime)));
 
 			$oldExpiration = $this->client->getSet($lockKey, $timeout = $this->calculateTimeout());
 			if ($oldExpiration === $lockExpiration) {


### PR DESCRIPTION
It could stay in cycling process for a long time now. However This pull should make fault faster in bad cases. It could take around 80 seconds very easily.

Extending sleep time each could safe a lot of tries. The additional condition affects count of max attempts in inner cycle. With current logic it takes 8 iterations in the worst case. Maximum of total attempts is 80 with waiting of maximum 13 seconds.