### PR TITLE
Session handler: removed destructor

### DIFF
--- a/src/Kdyby/Redis/RedisSessionHandler.php
+++ b/src/Kdyby/Redis/RedisSessionHandler.php
@@ -231,11 +231,4 @@ class RedisSessionHandler extends Nette\Object implements \SessionHandlerInterfa
 		return self::NS_NETTE . $id;
 	}
 
-
-
-	public function __destruct()
-	{
-		$this->close();
-	}
-
 }


### PR DESCRIPTION
It is not reliable, see the doc: http://php.net/manual/en/function.session-set-save-handler.php#refsect1-function.session-set-save-handler-notes

I had an issue that in some cases destructor was called before write and close. Sometimes, it wasn't called at all.