### PR TITLE
Unlock on remove

### DIFF
--- a/src/Kdyby/Redis/RedisStorage.php
+++ b/src/Kdyby/Redis/RedisStorage.php
@@ -260,6 +260,7 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 	public function remove($key)
 	{
 		$this->client->send('del', array($this->formatEntryKey($key)));
+		$this->unlock($key);
 	}
 
 


### PR DESCRIPTION
Lock must be released also on remove, not only on write in RedisStorage (see Nette\Caching\IStorage::lock comment).