### PR TITLE
Mute warning on failing connect for Redis extension version >= 3.1.0

### DIFF
--- a/src/Kdyby/Redis/Driver/PhpRedisDriver.php
+++ b/src/Kdyby/Redis/Driver/PhpRedisDriver.php
@@ -27,7 +27,7 @@ class PhpRedisDriver extends \Redis implements Kdyby\Redis\IRedisDriver
 	public function connect($host, $port = NULL, $timeout = 0)
 	{
 		$args = func_get_args();
-		return call_user_func_array('parent::connect', $args);
+		return @call_user_func_array('parent::connect', $args); // intentionally @ - from v3.1.0 Redis::connect() throws warning on failed
 	}
 
 


### PR DESCRIPTION
Redis extension from version 3.1.0 throws warning when connect failed, I think it's better to keep only TRUE/FALSE as success return value,