### PR TITLE
RedisStorage: getUnserializedValue Exception and error

### DIFF
--- a/src/Kdyby/Redis/RedisStorage.php
+++ b/src/Kdyby/Redis/RedisStorage.php
@@ -379,8 +379,18 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 		if (empty($stored[0][self::META_SERIALIZED])) {
 			return $stored[1];
 
-		} else {
-			return @unserialize($stored[1]); // intentionally @
+		}
+		try {
+			$value = @unserialize($stored[1]); // intentionally @
+			if ($value === FALSE && $stored[1] !== serialize(FALSE)) {
+				return NULL;
+			}
+
+			return $value;
+		} catch (\Throwable $e) {
+			return NULL;
+		} catch (\Exception $e) {
+			return NULL;
 		}
 	}
 


### PR DESCRIPTION
When `@unserialize` returns FALSE because of error method `getUnserializedValue` will return NULL and Nette\Caching\Cache::load will regenerate this record. Same for Throwable/Exception thrown from objects implementing \Serializable interface.