### PR TITLE
Fix compatibility of PhpRedisDriver with \Redis. But BC Break

### DIFF
--- a/src/Kdyby/Redis/Driver/PhpRedisDriver.php
+++ b/src/Kdyby/Redis/Driver/PhpRedisDriver.php
@@ -24,7 +24,7 @@ class PhpRedisDriver extends \Redis implements Kdyby\Redis\IRedisDriver
 	/**
 	 * {@inheritdoc}
 	 */
-	public function connect($host, $port = NULL, $timeout = 0)
+	public function connect($host, $port = NULL, $timeout = NULL, $retry_interval = NULL)
 	{
 		$args = func_get_args();
 		return call_user_func_array('parent::connect', $args);
@@ -46,10 +46,10 @@ class PhpRedisDriver extends \Redis implements Kdyby\Redis\IRedisDriver
 	/**
 	 * {@inheritdoc}
 	 */
-	public function script($command, $script = NULL)
+	public function script($cmd, ...$args)
 	{
-		$args = func_get_args();
-		return call_user_func_array('parent::script', $args);
+		$function_args = func_get_args();
+		return call_user_func_array('parent::script', $function_args);
 	}
 
 

--- a/src/Kdyby/Redis/IRedisDriver.php
+++ b/src/Kdyby/Redis/IRedisDriver.php
@@ -178,9 +178,10 @@ interface IRedisDriver
 	 * @param string $host can be a host, or the path to a unix domain socket
 	 * @param int $port
 	 * @param int $timeout value in seconds (optional, default is 0 meaning unlimited)
+     * @param int $retry_interval value in seconds
 	 * @return bool
 	 */
-	function connect($host, $port = NULL, $timeout = 0);
+	function connect($host, $port = NULL, $timeout = NULL, $retry_interval = NULL);
 
 	/**
 	 * Change the selected database for the current connection.
@@ -210,11 +211,11 @@ interface IRedisDriver
 	/**
 	 * Execute the Redis SCRIPT command to perform various operations on the scripting subsystem.
 	 *
-	 * @param $command
-	 * @param $script
+	 * @param $cmd
+	 * @param ...$args
 	 * @return mixed
 	 */
-	function script($command, $script = NULL);
+	function script($cmd, ...$args);
 
 	/**
 	 * @param string $scriptSha The sha1 encoded hash of the script you want to run.


### PR DESCRIPTION
Hi,

this PR fixes the warning with incompatibility of `PhpRedisDriver::connect(...)` with `\Reids::connect(...)` and `PhpRedisDriver::script(...)` with `\Redis::script(...)`.

Tests are passing on Travis, so from this point of view it is good to go, but I am not sure about other stuff - more "deep" into code-base and apps I'd say.

Also this PR may brings **back-compatibility** break, but I have also updated the `IRedisDriver` interface. Maybe some of the PHPDocs is not correct, but one commit can easily fix it before merging.

Check the tests yourself: [![Build Status](https://travis-ci.org/vojtamares/Redis.svg?branch=master)](https://travis-ci.org/vojtamares/Redis)

https://travis-ci.org/vojtamares/Redis


This PR should fix issue #78 


Do you know about valuable replacement for `kdyby\redis` since it is no longer actively developed? Thank you.