### PR TITLE
add info about default database config

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -35,6 +35,14 @@ redis:
 	session: on
 ```
 
+### Default database
+
+By default, the extension will connect to redis database `0`. It may be beneficial to change this if there are multiple applications connecting to the same redis server. Default database can be changed by using the configuration option
+
+```yml
+redis:
+	database: 2	# default selected database on redis server will be 2
+```
 
 ## Journal
 


### PR DESCRIPTION
this is just a small update in the docs, setting up default database. Default database is 0, and it is clear from the docs, however, it is not super clear how to change that.

My first attempt was to do it the same way as in session config, i.e. `storage: {database: 2}`, but this does not work, and it took me little bit of time to figure out where it needs to go.

May be useful for somebody who is running multiple apps connecting to the same redis server. Feel free to reject if you don't think it's useful (but it would have been to me an hour ago :) )