### PR TITLE
Removed nette/reflection dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
 		"nette/di": "~2.4.10 || ~3.0",
 		"nette/caching": "~3.0",
 		"nette/http": "~2.4.7 || ~3.0",
-		"nette/utils": "~2.5 || ~3.0",
-		"nette/reflection": "^2.4"
+		"nette/utils": "~2.5 || ~3.0"
 	},
 	"suggest": {
 		"ext-redis": "The php redis extension https://github.com/nicolasff/phpredis/ is required for connecting to redis server"

--- a/tests/KdybyTests/Redis/AbstractRedisTestCase.php
+++ b/tests/KdybyTests/Redis/AbstractRedisTestCase.php
@@ -6,7 +6,6 @@ namespace KdybyTests\Redis;
 
 use Closure;
 use Kdyby\Redis\RedisClient;
-use Nette\Reflection\ClassType;
 use Nette\Utils\FileSystem;
 use ReflectionClass;
 use ReflectionFunctionAbstract;
@@ -91,10 +90,10 @@ abstract class AbstractRedisTestCase extends \Tester\TestCase
 		FileSystem::createDir($dir = \dirname($scriptFile));
 
 		$extractor = new ClosureExtractor($closure);
-		\file_put_contents($scriptFile, $extractor->buildScript(ClassType::from($this), $repeat));
+		$testRefl = new ReflectionClass($this);
+		\file_put_contents($scriptFile, $extractor->buildScript($testRefl, $repeat));
 		@\chmod($scriptFile, 0755);
 
-		$testRefl = new ReflectionClass($this);
 		$collector = new ResultsCollector(\dirname($testRefl->getFileName()) . '/output', $runTest['args'][0]);
 
 		// todo: fix for hhvm

--- a/tests/KdybyTests/Redis/ClosureExtractor.php
+++ b/tests/KdybyTests/Redis/ClosureExtractor.php
@@ -10,13 +10,13 @@ class ClosureExtractor
 	use \Nette\SmartObject;
 
 	/**
-	 * @var \Nette\Reflection\GlobalFunction
+	 * @var \ReflectionFunction
 	 */
 	private $closure;
 
 	public function __construct(\Closure $closure)
 	{
-		$this->closure = new \Nette\Reflection\GlobalFunction($closure);
+		$this->closure = new \ReflectionFunction($closure);
 	}
 
 	public function buildScript(


### PR DESCRIPTION
Package nette/reflection is not used.
Class references in test use only standard PHP reflection classes.