### PR TITLE
Nette Tester - update to version 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"tracy/tracy": "~2.4",
 
 		"kdyby/coding-standard": "dev-master",
-		"nette/tester": "~1.7",
+		"nette/tester": "^2.3.1",
 		"phpstan/phpstan": "^0.12",
 		"jakub-onderka/php-parallel-lint": "^1.0",
 		"php-coveralls/php-coveralls": "^2.1",

--- a/tests/KdybyTests/Redis/RedisSessionHandlerTest.phpt
+++ b/tests/KdybyTests/Redis/RedisSessionHandlerTest.phpt
@@ -13,7 +13,6 @@ namespace KdybyTests\Redis;
 use Kdyby\Redis\RedisClient;
 use Kdyby\Redis\RedisSessionHandler;
 use Nette;
-use Tester;
 use Tester\Assert;
 use Tracy\Debugger;
 
@@ -53,7 +52,7 @@ class RedisSessionHandlerTest extends \KdybyTests\Redis\AbstractRedisTestCase
 			$handler->write($sessionId, \serialize($session));
 			$handler->close();
 		});
-		Assert::same(100, $result[Tester\Runner\Runner::PASSED]);
+		Assert::same(100, $result->getPassingResults());
 
 		$handler = new RedisSessionHandler($this->client);
 
@@ -296,7 +295,7 @@ class RedisSessionHandlerTest extends \KdybyTests\Redis\AbstractRedisTestCase
 			$session->close(); // explicit close with unlock
 		}, 100, 30); // silence, I kill you!
 
-		self::assertRange(30, 40, $result[Tester\Runner\Runner::PASSED]);
+		self::assertRange(30, 40, $result->getPassingResults());
 
 			// hard unlock
 		$client->del('Nette.Session:' . $sessionId . ':lock');


### PR DESCRIPTION
Update Nette Tester to version 2.3.

Replaces PR https://github.com/Kdyby/Redis/pull/86, uses PHP interpreter creation from https://github.com/martinvenus/Redis/pull/1.
