### PR TITLE
Added support for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,16 @@ matrix:
       env: COMPOSER_EXTRA_ARGS="" PHPSTAN=1 RUN_TESTS=0
     - php: 7.4
       env: COMPOSER_EXTRA_ARGS="" CODING_STANDARD=1 RUN_TESTS=0
+    - php: 8.0
+      env: RUN_TESTS=1 COMPOSER_EXTRA_ARGS="--ignore-platform-reqs" # dev
+    - php: 8.0
+      env: RUN_TESTS=1 COMPOSER_EXTRA_ARGS="--prefer-stable --ignore-platform-reqs" # because of incompatible dev dependencies
   exclude:
     - php: 7.4
       env: COMPOSER_EXTRA_ARGS=""
   allow_failures:
     - env: RUN_TESTS=1
+    - env: RUN_TESTS=1 COMPOSER_EXTRA_ARGS="--ignore-platform-reqs"
 
 before_install:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Kdyby/Redis
 Requirements
 ------------
 
-Kdyby/Redis requires PHP 7.1 to PHP 7.4.
+Kdyby/Redis requires PHP 7.1 or newer.
 
 - [Nette Framework](https://github.com/nette/nette)
 - [Redis database](http://redis.io)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"issues": "https://github.com/kdyby/redis/issues"
 	},
 	"require": {
-		"php": "^7.1",
+		"php": ">=7.1",
 		"ext-redis": "*",
 		"nette/di": "~2.4.10 || ~3.0",
 		"nette/caching": "~3.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,18 +2,14 @@ parameters:
 	ignoreErrors:
 		- '#Result of function usleep \(void\) is used.#'
 		- '#Constant TEMP_DIR not found.#'
-		- '#Unsafe usage of new static().#'
+		- '#Unsafe usage of new static\(\).#'
 		-
 			message: '#Negated boolean expression is always true.#'
 			path: src/Kdyby/Redis/ExclusiveLock.php
-		-
-			message: '#Declaration of Kdyby\\Redis\\Driver\\PhpRedisDriverOld::script\(.*\) should be compatible with Redis::script\(.*\)#'
-			path: src/Kdyby/Redis/Driver/PhpRedisDriverOld.php
-		-
-			message: '#Declaration of Kdyby\\Redis\\Driver\\PhpRedisDriverOld::connect\(.*\): bool should be compatible with Redis::connect\(.*\)#'
-			path: src/Kdyby/Redis/Driver/PhpRedisDriverOld.php
 
 	excludes_analyse:
 		- src/Kdyby/Redis/DI/ClassAliasMap.php
+		# PhpRedisDriverOld can't be verified because it overrides class Redis from phpredis older than 4.0
+		- src/Kdyby/Redis/Driver/PhpRedisDriverOld.php
 
 	reportUnmatchedIgnoredErrors: FALSE

--- a/tests/KdybyTests/Redis/NamespaceUses.php
+++ b/tests/KdybyTests/Redis/NamespaceUses.php
@@ -42,6 +42,12 @@ class NamespaceUses
 	 */
 	private function parseFile(): array
 	{
+		// Compatibility with PHP 8.0 namespace handling for older PHP
+		if (!defined('T_NAME_FULLY_QUALIFIED')) {
+			define('T_NAME_FULLY_QUALIFIED', -1);
+			define('T_NAME_QUALIFIED', -1);
+		}
+
 		$code = \file_get_contents($this->refl->getFileName());
 
 		$expected = FALSE;
@@ -66,6 +72,8 @@ class NamespaceUses
 
 					case T_NS_SEPARATOR:
 					case T_STRING:
+					case T_NAME_QUALIFIED:
+					case T_NAME_FULLY_QUALIFIED:
 						if ($expected) {
 							$name .= $token[1];
 							continue 2;
@@ -104,7 +112,7 @@ class NamespaceUses
 						}
 
 						if ($token === ';') {
-							$list = \array_map(\Nette\Utils\Callback::closure('trim'), \explode(',', $name));
+							$list = \array_map(\Closure::fromCallable('trim'), \explode(',', $name));
 							$uses[$namespace] = isset($uses[$namespace]) ? \array_merge(
 								$uses[$namespace],
 								$list

--- a/tests/travis.phpredis.sh
+++ b/tests/travis.phpredis.sh
@@ -2,7 +2,7 @@
 
 mkdir /tmp/build-phpredis && cd /tmp/build-phpredis || exit 1
 
-wget -O phpredis.zip "https://github.com/phpredis/phpredis/archive/master.zip" && unzip phpredis.zip && cd phpredis-*/ || exit 1
+wget -O phpredis.zip "https://github.com/phpredis/phpredis/archive/develop.zip" && unzip phpredis.zip && cd phpredis-*/ || exit 1
 echo
 
 phpize && ./configure && make && make install || exit 1


### PR DESCRIPTION
- Allow installation on PHP 8.0
- Fixed compatibility with PHP 8.0 namespace handling
- Ignore platform requirements on PHP 8.0 because of incompatible dev dependency
- Updated download URL for phpredis extension
- Fixed warning for phpstan.neon
