### PR TITLE
Fix: Config schema is normalized

### DIFF
--- a/src/Kdyby/Redis/DI/Config/ClientSchema.php
+++ b/src/Kdyby/Redis/DI/Config/ClientSchema.php
@@ -36,6 +36,7 @@ class ClientSchema implements \Nette\Schema\Schema
 	{
 		$value = $this->expandParameters($value);
 
+		$value = $this->getSchema()->normalize($value, $context);
 		$value = $this->getSchema()->complete($value, $context);
 
 		return $value;

--- a/src/Kdyby/Redis/DI/Config/RedisSchema.php
+++ b/src/Kdyby/Redis/DI/Config/RedisSchema.php
@@ -54,8 +54,9 @@ class RedisSchema implements \Nette\Schema\Schema
 
 	public function complete($value, \Nette\Schema\Context $context)
 	{
-		$value = $this->expandParameters($value);
+		$value = $this->expandParameters((array) $value);
 
+		$value = $this->normalize($value, $context);
 		$value = $this->getSchema()->complete($value, $context);
 
 		return $value;

--- a/tests/KdybyTests/Redis/ExtensionTest.phpt
+++ b/tests/KdybyTests/Redis/ExtensionTest.phpt
@@ -22,13 +22,20 @@ require_once __DIR__ . '/../bootstrap.php';
 class ExtensionTest extends \Tester\TestCase
 {
 
-	protected function createContainer(): Container
+	protected function createConfig(): \Nette\Bootstrap\Configurator
 	{
-		$config = new Nette\Configurator();
+		$config = new \Nette\Bootstrap\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
 		$config->onCompile[] = static function ($config, Nette\DI\Compiler $compiler): void {
 			$compiler->addExtension('redis', new Kdyby\Redis\DI\RedisExtension());
 		};
+
+		return $config;
+	}
+
+	protected function createContainer(): Container
+	{
+		$config = $this->createConfig();
 
 		$config->addConfig(__DIR__ . '/files/config.neon');
 
@@ -95,6 +102,15 @@ class ExtensionTest extends \Tester\TestCase
 
 		Assert::true(isset($sessionOptions['cookie_secure']));
 		Assert::same(FALSE, $sessionOptions['cookie_secure']);
+	}
+
+	public function testWithoutConfiguration(): void
+	{
+		$config = $this->createConfig();
+		$dic = $config->createContainer();
+		Assert::true($dic->getService('redis.client') instanceof Kdyby\Redis\RedisClient);
+		Assert::false($dic->hasService('redis.cacheJournal'));
+		Assert::false($dic->hasService('redis.cacheStorage'));
 	}
 
 }


### PR DESCRIPTION
Providing no config section for DI extension results in type error exception. This PR fixes this type erro and also fills configuration with default connection parameters.