### PR TITLE
Fix: Config schema normalization is not processed twice

### DIFF
--- a/src/Kdyby/Redis/DI/Config/ClientSchema.php
+++ b/src/Kdyby/Redis/DI/Config/ClientSchema.php
@@ -15,6 +15,8 @@ class ClientSchema implements \Nette\Schema\Schema
 
 	public function normalize($value, \Nette\Schema\Context $context)
 	{
+		$value = $this->getSchema()->normalize($value, $context);
+
 		if (\array_key_exists('host', $value) && $value['host'][0] === '/') {
 			$value['port'] = NULL; // sockets have no ports
 
@@ -36,7 +38,6 @@ class ClientSchema implements \Nette\Schema\Schema
 	{
 		$value = $this->expandParameters($value);
 
-		$value = $this->getSchema()->normalize($value, $context);
 		$value = $this->getSchema()->complete($value, $context);
 
 		return $value;

--- a/src/Kdyby/Redis/DI/Config/RedisSchema.php
+++ b/src/Kdyby/Redis/DI/Config/RedisSchema.php
@@ -56,7 +56,6 @@ class RedisSchema implements \Nette\Schema\Schema
 	{
 		$value = $this->expandParameters((array) $value);
 
-		$value = $this->normalize($value, $context);
 		$value = $this->getSchema()->complete($value, $context);
 
 		return $value;
@@ -89,7 +88,21 @@ class RedisSchema implements \Nette\Schema\Schema
 				'session' => \Nette\Schema\Expect::bool(FALSE),
 				'clients' => \Nette\Schema\Expect::arrayOf(
 					new \Kdyby\Redis\DI\Config\ClientSchema($this->builder)
-				)->default([]),
+				)->default([
+					NULL => [
+						'host' => '127.0.0.1',
+						'port' => \Kdyby\Redis\RedisClient::DEFAULT_PORT,
+						'timeout' => 10,
+						'database' => 0,
+						'auth' => NULL,
+						'persistent' => FALSE,
+						'connectionAttempts' => 1,
+						'lockDuration' => 15,
+						'lockAcquireTimeout' => FALSE,
+						'debugger' => $this->builder->parameters['debugMode'],
+						'versionCheck' => TRUE,
+					],
+				]),
 			]);
 		}
 

--- a/src/Kdyby/Redis/RedisClient.php
+++ b/src/Kdyby/Redis/RedisClient.php
@@ -180,7 +180,7 @@ class RedisClient implements \ArrayAccess
 	private $host;
 
 	/**
-	 * @var int
+	 * @var ?int
 	 */
 	private $port;
 
@@ -218,14 +218,14 @@ class RedisClient implements \ArrayAccess
 
 	/**
 	 * @param string $host
-	 * @param int $port
+	 * @param ?int $port
 	 * @param int $database
 	 * @param int $timeout
 	 * @param string $auth
 	 * @param bool $persistent
 	 * @throws \Kdyby\Redis\Exception\MissingExtensionException
 	 */
-	public function __construct(string $host = '127.0.0.1', int $port = 6379, int $database = 0, int $timeout = 10, ?string $auth = NULL, bool $persistent = FALSE)
+	public function __construct(string $host = '127.0.0.1', ?int $port = 6379, int $database = 0, int $timeout = 10, ?string $auth = NULL, bool $persistent = FALSE)
 	{
 		$this->host = $host;
 		$this->port = $port;

--- a/tests/KdybyTests/Redis/ExtensionTest.phpt
+++ b/tests/KdybyTests/Redis/ExtensionTest.phpt
@@ -123,6 +123,16 @@ class ExtensionTest extends \Tester\TestCase
 		Assert::false($dic->hasService('redis.cacheStorage'));
 	}
 
+	public function testSocketConfiguration(): void
+	{
+		$config = $this->createConfig();
+		$config->addConfig(__DIR__ . '/files/socket.neon');
+		$dic = $config->createContainer();
+		Assert::true($dic->getService('redis.client') instanceof Kdyby\Redis\RedisClient);
+		Assert::false($dic->hasService('redis.cacheJournal'));
+		Assert::false($dic->hasService('redis.cacheStorage'));
+	}
+
 }
 
 (new ExtensionTest())->run();

--- a/tests/KdybyTests/Redis/ExtensionTest.phpt
+++ b/tests/KdybyTests/Redis/ExtensionTest.phpt
@@ -113,6 +113,16 @@ class ExtensionTest extends \Tester\TestCase
 		Assert::false($dic->hasService('redis.cacheStorage'));
 	}
 
+	public function testOfflineConfiguration(): void
+	{
+		$config = $this->createConfig();
+		$config->addConfig(__DIR__ . '/files/offline.neon');
+		$dic = $config->createContainer();
+		Assert::true($dic->getService('redis.client') instanceof Kdyby\Redis\RedisClient);
+		Assert::false($dic->hasService('redis.cacheJournal'));
+		Assert::false($dic->hasService('redis.cacheStorage'));
+	}
+
 }
 
 (new ExtensionTest())->run();

--- a/tests/KdybyTests/Redis/files/offline.neon
+++ b/tests/KdybyTests/Redis/files/offline.neon
@@ -1,0 +1,6 @@
+redis:
+	journal: false
+	storage: false
+	session: false
+	versionCheck: false
+	host: localhost

--- a/tests/KdybyTests/Redis/files/socket.neon
+++ b/tests/KdybyTests/Redis/files/socket.neon
@@ -1,0 +1,6 @@
+redis:
+	journal: false
+	storage: false
+	session: false
+	versionCheck: false
+	host: /tmp/redis.sock


### PR DESCRIPTION
Lessons learned: keep normalization and completion separate

Calling normalize in complete function caused double normalization which led to breaking BC with client configuration in root section of extension config and was overwritten by default configuration.