### PR TITLE
Fix: session and storage config sections can be client definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: redis
+          extensions: redis, igbinary
+        env:
+          REDIS_CONFIGURE_OPTS: --enable-redis --enable-redis-igbinary
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.2.0

--- a/src/Kdyby/Redis/DI/Config/ClientSchema.php
+++ b/src/Kdyby/Redis/DI/Config/ClientSchema.php
@@ -81,7 +81,7 @@ class ClientSchema implements \Nette\Schema\Schema
 			'lockAcquireTimeout' => \Nette\Schema\Expect::bool(FALSE),
 			'debugger' => \Nette\Schema\Expect::bool($this->builder->parameters['debugMode']),
 			'versionCheck' => \Nette\Schema\Expect::bool(TRUE),
-		]);
+		])->castTo('array');
 	}
 
 }

--- a/src/Kdyby/Redis/DI/Config/RedisSchema.php
+++ b/src/Kdyby/Redis/DI/Config/RedisSchema.php
@@ -82,15 +82,17 @@ class RedisSchema implements \Nette\Schema\Schema
 	private function getSchema(): \Nette\Schema\Schema
 	{
 		if ($this->schema === NULL) {
-			$clientSchema = new \Kdyby\Redis\DI\Config\ClientSchema($this->builder);
-			$sessionClientSchema = new SessionClientSchema($this->builder);
+			$storageSchema = \Nette\Schema\Expect::structure([
+				'locks' => \Nette\Schema\Expect::bool(TRUE),
+			])->castTo('array');
+			$sessionClientSchema = new \Kdyby\Redis\DI\Config\SessionClientSchema($this->builder);
 
 			$this->schema = \Nette\Schema\Expect::structure([
 				'journal' => \Nette\Schema\Expect::bool(FALSE),
-				'storage' => \Nette\Schema\Expect::anyOf($clientSchema, TRUE, FALSE)->default(FALSE),
+				'storage' => \Nette\Schema\Expect::anyOf($storageSchema, TRUE, FALSE)->default(FALSE),
 				'session' => \Nette\Schema\Expect::anyOf($sessionClientSchema, TRUE, FALSE)->default(FALSE),
 				'clients' => \Nette\Schema\Expect::arrayOf(
-					$clientSchema
+					new \Kdyby\Redis\DI\Config\ClientSchema($this->builder)
 				)->default([
 					NULL => [
 						'host' => '127.0.0.1',
@@ -106,7 +108,7 @@ class RedisSchema implements \Nette\Schema\Schema
 						'versionCheck' => TRUE,
 					],
 				]),
-			]);
+			])->castTo('array');
 		}
 
 		return $this->schema;

--- a/src/Kdyby/Redis/DI/Config/RedisSchema.php
+++ b/src/Kdyby/Redis/DI/Config/RedisSchema.php
@@ -82,12 +82,15 @@ class RedisSchema implements \Nette\Schema\Schema
 	private function getSchema(): \Nette\Schema\Schema
 	{
 		if ($this->schema === NULL) {
+			$clientSchema = new \Kdyby\Redis\DI\Config\ClientSchema($this->builder);
+			$sessionClientSchema = new SessionClientSchema($this->builder);
+
 			$this->schema = \Nette\Schema\Expect::structure([
 				'journal' => \Nette\Schema\Expect::bool(FALSE),
-				'storage' => \Nette\Schema\Expect::bool(FALSE),
-				'session' => \Nette\Schema\Expect::bool(FALSE),
+				'storage' => \Nette\Schema\Expect::anyOf($clientSchema, TRUE, FALSE)->default(FALSE),
+				'session' => \Nette\Schema\Expect::anyOf($sessionClientSchema, TRUE, FALSE)->default(FALSE),
 				'clients' => \Nette\Schema\Expect::arrayOf(
-					new \Kdyby\Redis\DI\Config\ClientSchema($this->builder)
+					$clientSchema
 				)->default([
 					NULL => [
 						'host' => '127.0.0.1',

--- a/src/Kdyby/Redis/DI/Config/SessionClientSchema.php
+++ b/src/Kdyby/Redis/DI/Config/SessionClientSchema.php
@@ -84,7 +84,7 @@ class SessionClientSchema implements \Nette\Schema\Schema
 			'native' => \Nette\Schema\Expect::bool(TRUE),
 			'prefix' => \Nette\Schema\Expect::string(\Kdyby\Redis\DI\RedisExtension::DEFAULT_SESSION_PREFIX),
 			'weight' => \Nette\Schema\Expect::int(1),
-		]);
+		])->castTo('array');
 	}
 
 }

--- a/src/Kdyby/Redis/DI/Config/SessionClientSchema.php
+++ b/src/Kdyby/Redis/DI/Config/SessionClientSchema.php
@@ -2,7 +2,7 @@
 
 namespace Kdyby\Redis\DI\Config;
 
-class ClientSchema implements \Nette\Schema\Schema
+class SessionClientSchema implements \Nette\Schema\Schema
 {
 
 	private \Nette\DI\ContainerBuilder $builder;
@@ -79,8 +79,11 @@ class ClientSchema implements \Nette\Schema\Schema
 			'connectionAttempts' => \Nette\Schema\Expect::int(1),
 			'lockDuration' => \Nette\Schema\Expect::int(15),
 			'lockAcquireTimeout' => \Nette\Schema\Expect::bool(FALSE),
-			'debugger' => \Nette\Schema\Expect::bool($this->builder->parameters['debugMode']),
+			'debugger' => \Nette\Schema\Expect::bool(FALSE),
 			'versionCheck' => \Nette\Schema\Expect::bool(TRUE),
+			'native' => \Nette\Schema\Expect::bool(TRUE),
+			'prefix' => \Nette\Schema\Expect::string(\Kdyby\Redis\DI\RedisExtension::DEFAULT_SESSION_PREFIX),
+			'weight' => \Nette\Schema\Expect::int(1),
 		]);
 	}
 

--- a/tests/KdybyTests/Redis/ExtensionTest.phpt
+++ b/tests/KdybyTests/Redis/ExtensionTest.phpt
@@ -139,6 +139,8 @@ class ExtensionTest extends \Tester\TestCase
 		$config->addConfig(__DIR__ . '/files/session.neon');
 		$dic = $config->createContainer();
 		Assert::true($dic->getService('redis.client') instanceof Kdyby\Redis\RedisClient);
+		Assert::true($dic->hasService('redis.sessionHandler'));
+		Assert::type(\Kdyby\Redis\RedisSessionHandler::class, $dic->getService('redis.sessionHandler'));
 		Assert::false($dic->hasService('redis.cacheJournal'));
 		Assert::false($dic->hasService('redis.cacheStorage'));
 	}

--- a/tests/KdybyTests/Redis/ExtensionTest.phpt
+++ b/tests/KdybyTests/Redis/ExtensionTest.phpt
@@ -133,6 +133,16 @@ class ExtensionTest extends \Tester\TestCase
 		Assert::false($dic->hasService('redis.cacheStorage'));
 	}
 
+	public function testSessionConfiguration(): void
+	{
+		$config = $this->createConfig();
+		$config->addConfig(__DIR__ . '/files/session.neon');
+		$dic = $config->createContainer();
+		Assert::true($dic->getService('redis.client') instanceof Kdyby\Redis\RedisClient);
+		Assert::false($dic->hasService('redis.cacheJournal'));
+		Assert::false($dic->hasService('redis.cacheStorage'));
+	}
+
 }
 
 (new ExtensionTest())->run();

--- a/tests/KdybyTests/Redis/files/session.neon
+++ b/tests/KdybyTests/Redis/files/session.neon
@@ -1,0 +1,7 @@
+redis:
+	journal: false
+	storage: false
+	session:
+		database: 1
+		native: false
+	versionCheck: false


### PR DESCRIPTION
fixes #106 