### PR TITLE
Fix compatibility with Nette/Caching v3.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php": ">=7.4",
 		"ext-redis": "*",
 		"nette/di": "~3.0",
-		"nette/caching": "~3.0",
+		"nette/caching": "~3.1",
 		"nette/http": "~3.0",
 		"nette/utils": "~3.0"
 	},

--- a/src/Kdyby/Redis/RedisStorage.php
+++ b/src/Kdyby/Redis/RedisStorage.php
@@ -29,6 +29,7 @@ class RedisStorage implements \Kdyby\Redis\IMultiReadStorage
 	 * @internal
 	 */
 	private const NS_NETTE = 'Nette.Storage';
+	private const NAMESPACE_SEPARATOR = "\x00";
 
 	/**
 	 * cache meta structure: array of
@@ -215,7 +216,7 @@ class RedisStorage implements \Kdyby\Redis\IMultiReadStorage
 			$meta[self::META_SERIALIZED] = TRUE;
 		}
 
-		$store = \json_encode($meta) . Cache::NAMESPACE_SEPARATOR . $data;
+		$store = \json_encode($meta) . self::NAMESPACE_SEPARATOR . $data;
 
 		try {
 			if (isset($dp[Cache::EXPIRATION])) {
@@ -275,7 +276,7 @@ class RedisStorage implements \Kdyby\Redis\IMultiReadStorage
 
 	protected function formatEntryKey(string $key): string
 	{
-		return self::NS_NETTE . ':' . \str_replace(Cache::NAMESPACE_SEPARATOR, ':', $key);
+		return self::NS_NETTE . ':' . \str_replace(self::NAMESPACE_SEPARATOR, ':', $key);
 	}
 
 	/**
@@ -334,7 +335,7 @@ class RedisStorage implements \Kdyby\Redis\IMultiReadStorage
 	 */
 	private static function processStoredValue(string $key, string $storedValue): array
 	{
-		[$meta, $data] = \explode(Cache::NAMESPACE_SEPARATOR, $storedValue, 2) + [NULL, NULL];
+		[$meta, $data] = \explode(self::NAMESPACE_SEPARATOR, $storedValue, 2) + [NULL, NULL];
 		return [[self::KEY => $key] + \json_decode($meta, TRUE), $data];
 	}
 


### PR DESCRIPTION
- at last version of Nette/Caching https://github.com/nette/caching/releases/tag/v3.1.3 was changed name of constant `NAMESPACE_SEPARATOR` to `NamespaceSeparator`
- because constant is **internal**, i moved it to RedisStorage class