### PR TITLE
Allow use of nette/utils 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"nette/di": "~3.0",
 		"nette/caching": "~3.1",
 		"nette/http": "~3.0",
-		"nette/utils": "~3.0"
+		"nette/utils": "~3.0 || ^4.0"
 	},
 	"suggest": {
 		"ext-redis": "The php redis extension https://github.com/nicolasff/phpredis/ is required for connecting to redis server"
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"nette/bootstrap": "~3.0",
 		"nette/deprecated": "~3.0",
-		"nette/php-generator": "~3.3",
+		"nette/php-generator": "~3.3 || ^4.0",
 		"tracy/tracy": "~2.4",
 		"slevomat/coding-standard": "dev-master",
 		"nette/tester": "^2.3.1",

--- a/tests/KdybyTests/Redis/ClosureExtractor.php
+++ b/tests/KdybyTests/Redis/ClosureExtractor.php
@@ -38,13 +38,14 @@ DOC;
 		$code .= "\n\nnamespace " . $class->getNamespaceName() . ";\n\n";
 		$code .= 'use ' . \implode(";\n" . 'use ', $uses->parse()) . ";\n\n";
 
+		$dumper = new \Nette\PhpGenerator\Dumper();
 		// bootstrap
-		$code .= \Nette\PhpGenerator\Helpers::formatArgs('require_once ?;', [__DIR__ . '/../bootstrap.php']) . "\n";
+		$code .= $dumper->format('require_once ?;', __DIR__ . '/../bootstrap.php') . "\n";
 		$code .= '\Tester\Environment::$checkAssertions = FALSE;' . "\n";
-		$code .= \Nette\PhpGenerator\Helpers::formatArgs('\Tracy\Debugger::$logDirectory = ?;', [TEMP_DIR]) . "\n\n\n";
+		$code .= $dumper->format('\Tracy\Debugger::$logDirectory = ?;', TEMP_DIR) . "\n\n\n";
 
 		// script
-		$code .= \Nette\PhpGenerator\Helpers::formatArgs('extract(?);', [$this->closure->getStaticVariables()]) . "\n\n";
+		$code .= $dumper->format('extract(?);', $this->closure->getStaticVariables()) . "\n\n";
 		$code .= $codeParser->parse() . "\n\n\n";
 
 		return $code;


### PR DESCRIPTION
Allows usage of nette/utils and php/generator 4.0.
Also replaces usage of methods deprecated in newer nette/php-generator.